### PR TITLE
Board api 수정

### DIFF
--- a/naverCafe/src/API/BoardAPI.tsx
+++ b/naverCafe/src/API/BoardAPI.tsx
@@ -1,13 +1,15 @@
 import axios from "axios";
 import { useCallback, useState, useEffect } from "react";
 import { baseURL } from "../Constants";
-import { Article, Board } from "../Types";
+import { ArticleType, Board } from "../Types";
 
 export function useWholeBoard() {
-  const [boardList, setBoardList] = useState({"boards":[
-    { id: 1, name: "스프링" },
-    { id: 2, name: "장고" },
-  ]});
+  const [boardList, setBoardList] = useState({
+    boards: [
+      { id: 1, name: "스프링" },
+      { id: 2, name: "장고" },
+    ],
+  });
   const url = "/api/v1/boards";
   const refetch = useCallback(async () => {
     const res = await axios.get(baseURL + url);
@@ -68,7 +70,9 @@ export function useArticleList({
   boardId?: number;
   type?: string;
 }) {
-  const [articleList, setArticleList] = useState<Article[] | null>(null);
+  const [articleList, setArticleList] = useState<{
+    articles: ArticleType[];
+  } | null>(null);
 
   const url =
     type === undefined

--- a/naverCafe/src/Types.tsx
+++ b/naverCafe/src/Types.tsx
@@ -1,20 +1,42 @@
-
-
 export type Board = {
   id: number;
   name: string;
 };
 
-export type Article = {
+export type ArticleType = {
   id: number;
   title: string;
-  createdAt: string;
-  viewCnt: number;
-  likeCnt: number;
-  comment_count: number;
-  user: { id: number; username: string };
-  board: Board;
-  isNotification: boolean;
+  content: string;
+  nickname: string;
+  created_at: string;
+  view_cnt: number;
+  like_cnt: number;
+  like_users: {
+    nickname: string;
+    liked_at: string;
+  }[];
+  user: {
+    nickname: string;
+    username: string;
+  };
+  board: {
+    board_id: number;
+    board_name: string;
+  };
+  allow_comments: boolean;
+  is_notification: boolean;
+};
+export type CommentType = {
+  id: number;
+  content: string;
+  last_modified: string;
+  nickname: string;
+  recomments: {
+    id: number;
+    content: string;
+    last_modified: string;
+    nickname: string;
+  }[];
 };
 
 //GET (activity)


### PR DESCRIPTION
안녕하세요, board api 중 useArticleList() 사용할 일이 있어서 사용하다가, board api에 수정 사항 제안드리려고 PR 올립니다...! 혹시 다른 의견 있으시면 말씀해주세요! 수정내용은 다음과 같습니다. 

1. "Article" type -> "ArticleType" type
-> 타입 이름이 컴포넌트 이름과 겹쳐서 오류가 뜨는 일이 있어서 타입 이름을 바꿉니다.. 또, Article 타입을 back에서 받아오는 데이터 형식로 바꿉니다..(그 형식은 아래와 같습니다.) Article type을 백에서 받아오는 데이터의 형식이 아니라 따로 만들어서 사용하다보니, 여러 컴포넌트 상에서 통일이 안되어서 조금 헷갈리기도 하고 불편해서 이렇게 바꾸는 게 어떤지 제안드립니다.
2. useArticleList() 내부의 articleList state의 generic 변경(useState<Article[] | null>(null) -> useState<{articles: ArticleType[]} | null>)
->  받는 데이터는 articles 프로퍼티 안에 ArticleType[]이 있는 구조이기 때문에 이렇게 변경하는 게 어떤지 제안드립니다.