### PR TITLE
로그인 후 access token 및 유저 정보 저장 구현 수정

### DIFF
--- a/naverCafe/src/API/ArticleAPI.tsx
+++ b/naverCafe/src/API/ArticleAPI.tsx
@@ -61,9 +61,12 @@ export function deleteArticle(articleId: number) {
 }
 // article 조회(get)
 // article의 좋아요, 댓글 등이 바뀌었을 때 refetch 할 수 있어야 하므로, state로 받는 데이터 관리하고, refetch 함수 정의하겠습니다.
-// username을 쿼리로 전달해야하는가?(api 명세에서는 그렇게 되어 있음)
+// username을 쿼리로 전달해야하는가?(api 명세에서는 그렇게 되어 있음) -> 인증 기반이면 필요없을듯
 export function useArticle(articleId: number) {
-  const [article, setArticle] = useState<ArticleType | null>(null);
+  const [article, setArticle] = useState<{
+    article: ArticleType;
+    isLiked: boolean;
+  } | null>(null);
   const url = `/api/v1/articles/${articleId}`;
   const refetchArticle = useCallback(async () => {
     const res = await axios.get(baseURL + url, {
@@ -99,14 +102,17 @@ export function deleteLike(articleId: number) {
 }
 // article 공지로 등록 -> 이 기능이 필요한가?
 // 모든 article 조회 -> 이 기능이 필요한가?
-  
+
 // 전체 article 조회
 export function wholeArticle() {
-  return axios.get(baseURL + `api/v1/articles`).then((res) => {
-    console.log(res);
-    return res;
-  }).catch((err) => {
-    console.log(err);
-    return;
-  });
+  return axios
+    .get(baseURL + `api/v1/articles`)
+    .then((res) => {
+      console.log(res);
+      return res;
+    })
+    .catch((err) => {
+      console.log(err);
+      return;
+    });
 }

--- a/naverCafe/src/API/BoardAPI.tsx
+++ b/naverCafe/src/API/BoardAPI.tsx
@@ -21,9 +21,9 @@ export function useWholeBoard() {
 }
 
 export function useBoardGroup() {
-  const [groupList, setBoardList] = useState<{ boardGroups: GroupType[] } | null>(
-    null
-  );
+  const [groupList, setBoardList] = useState<{
+    boardGroups: GroupType[];
+  } | null>(null);
   const url = "/api/v1/boards-in-group";
   const refetch = useCallback(async () => {
     const res = await axios.get(baseURL + url);
@@ -61,7 +61,6 @@ export function useGetLikeBoard(userId: string) {
   return { boardList, refetch };
 }
 
-
 //게시판별 게시물 리스트 및 인기게시판 게시물 리스트
 export function useArticleList({
   boardId,
@@ -71,7 +70,7 @@ export function useArticleList({
   type?: string;
 }) {
   const [articleList, setArticleList] = useState<{
-    articles: ArticleType[];
+    articleBrief: ArticleType[];
   } | null>(null);
 
   const url =

--- a/naverCafe/src/API/UserAPI.tsx
+++ b/naverCafe/src/API/UserAPI.tsx
@@ -9,12 +9,8 @@ export function signup(userInfo: {
   birthDate: string;
   phoneNumber: string;
 }) {
-  return axios.post(baseURL + "/api/v1/signup", {
-    userInfo,
-  });
+  return axios.post(baseURL + "/api/v1/signup", userInfo);
 }
 export function login(userInfo: { username: string; password: string }) {
-  return axios.post(baseURL + "/api/v1/signin", {
-    userInfo,
-  });
+  return axios.post(baseURL + "/api/v1/signin", userInfo);
 }

--- a/naverCafe/src/App.tsx
+++ b/naverCafe/src/App.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { GlobalStyle } from "./contexts/StyleContext";
 import { Route, Routes } from "react-router-dom";
 
-import { UserContext } from "./contexts/UserContext";
+import { AuthContext } from "./contexts/AuthContext";
 
 import Layout from "./pages/Layout";
 import SignUp from "./pages/SignUp";
@@ -23,7 +23,10 @@ import { useState } from "react";
 import { NoticeContextProvider } from "./contexts/BoardContext/NoticeContext";
 import { CurrentBoardStateProvider } from "./contexts/BoardContext/CurrentBoardContext";
 import { ViewOptionStateProvider } from "./contexts/BoardContext/ViewOptionContext";
-import { NickModalContext, NickModalContextProvider } from "./contexts/BoardContext/nickNameModalContext";
+import {
+  NickModalContext,
+  NickModalContextProvider,
+} from "./contexts/BoardContext/nickNameModalContext";
 
 const Wrapper = styled.div`
   margin: 0 auto;
@@ -33,19 +36,20 @@ const Wrapper = styled.div`
 function App() {
   const { boardList } = useWholeBoard();
 
-  // 자신의 정보를 담는 userInfo state를 context로서 사용하겠습니다.
-  const [myInfo, setMyInfo] = useState<{
-    userId: string;
-    username: string;
-    userNickname: string;
-  }>({
-    userId: "gryffindorGoat",
-    username: "harry potter",
-    userNickname: "해리포터",
-  });
+  // myUsername은 login할 때의 username입니다. login시 바뀝니다.
+  // -> 지금은 login 시 바뀌지만, 자신의 정보를 얻어오는 api가 추가된다면, 그 api에서 받아온 response를 기반으로 바꿀 생각입니다.
+  // 자신의 정보를 얻어오는 api에는 (아마도) id, username, name, nickname 정보를 받을 수 있을 텐데, 그 api가 완성되면 이 세 가지 정보를 담은 객체를 context value로 전달하도록 수정할 것 같습니다.
+  const [myUsername, setMyUsername] = useState<string>("");
+
+  // accessToken은 말 그대로 access token입니다. login 시 할당됩니다.
+  // 현재 로그인되어있는지 여부는 (myUsername !== "") 으로 알아보는 것으로 하겠습니다.
+  const [accessToken, setAccessToken] = useState<string>("");
+  console.log("myUsername:" + myUsername);
   return (
     <Wrapper>
-      <UserContext.Provider value={myInfo}>
+      <AuthContext.Provider
+        value={{ myUsername: myUsername, accessToken: accessToken }}
+      >
         <GlobalStyle />
         <PaginationProvider>
           <NoticeContextProvider>
@@ -55,7 +59,15 @@ function App() {
                   <Routes>
                     {/* 회원가입 및 로그인 page */}
                     <Route path="/signup" element={<SignUp />} />
-                    <Route path="/login" element={<Login />} />
+                    <Route
+                      path="/login"
+                      element={
+                        <Login
+                          setMyUsername={setMyUsername}
+                          setAccessToken={setAccessToken}
+                        />
+                      }
+                    />
 
                     {/* main page 구성 */}
                     {/* Layout은 header와 body로 나뉘어져 있습니다. */}
@@ -107,7 +119,7 @@ function App() {
             </CurrentBoardStateProvider>
           </NoticeContextProvider>
         </PaginationProvider>
-      </UserContext.Provider>
+      </AuthContext.Provider>
     </Wrapper>
   );
 }

--- a/naverCafe/src/Types.tsx
+++ b/naverCafe/src/Types.tsx
@@ -29,8 +29,8 @@ export type ArticleType = {
     accessToken: string;
   };
   board: {
-    board_id: number;
-    board_name: string;
+    id: number;
+    name: string;
   };
   allowComments: boolean;
   isNotification: boolean;
@@ -39,12 +39,12 @@ export type ArticleType = {
 export type CommentType = {
   id: number;
   content: string;
-  last_modified: string;
+  lastModified: string;
   nickname: string;
   recomments: {
     id: number;
     content: string;
-    last_modified: string;
+    lastModified: string;
     nickname: string;
   }[];
 };

--- a/naverCafe/src/components/Writing.tsx
+++ b/naverCafe/src/components/Writing.tsx
@@ -47,21 +47,26 @@ const Writing = () => {
     } else if (inputContent === "") {
       alert("내용을 입력해주세요.");
     } else {
-      await postArticle(
-        inputTitle,
-        inputContent,
-        1,
+      await postArticle({
+        title: inputTitle,
+        content: inputContent,
+        boardId: 1,
         // board id는 어떻게 처리되는지 모르겠어서 일단 이렇게 두었습니다.
-        isCommentAllowed,
-        isAnnouncement
-      ).then((res) => {
+        allowComments: isCommentAllowed,
+        isNotification: isAnnouncement,
+      }).then((res) => {
         if (res !== undefined) {
           navigate(`/articles/${res.data.id}`);
         }
       });
     }
   };
-
+  const stringToHTML = function (str) {
+    const dom = document.createElement("div");
+    dom.innerHTML = str;
+    return dom;
+  };
+  console.log(stringToHTML(inputContent).innerText);
   return (
     <Wrapper>
       <WritingHeader handleWritePost={handleWritePost} />

--- a/naverCafe/src/components/body/contents/article/Article.tsx
+++ b/naverCafe/src/components/body/contents/article/Article.tsx
@@ -351,6 +351,7 @@ const AdvertArea = styled.div`
 //     },
 //   ],
 // };
+
 const Article = () => {
   const { articleId } = useParams();
   const [isArticleLiked, setIsArticleLiked] = useState<boolean>(false);
@@ -360,6 +361,7 @@ const Article = () => {
   const navigate = useNavigate();
   const { article, refetchArticle } = useArticle(Number(articleId));
   const { comments } = useComments(Number(articleId));
+  console.log(article);
 
   // TOP 버튼을 눌렀을 때 위로 스크롤합니다.
   const TopButtonsRef = useRef<HTMLDivElement>(null);
@@ -418,170 +420,178 @@ const Article = () => {
     }
   }, [comments]);
 
-  return (
-    <Wrapper>
-      <ArticleTopButtons ref={TopButtonsRef}>
-        <div className="left">
-          <button className="edit auth">
-            <Link to={"/write"}>수정</Link>
-          </button>
-          <button className="delete auth">
-            <Link to={"/"}>삭제</Link>
-          </button>
-        </div>
-        <div className="right">
-          <button className="prevArticle">
-            {" "}
-            <Link to={"/"}>이전글</Link>
-          </button>
-          <button className="nextArticle">
-            <Link to={"/"}>다음글</Link>
-          </button>
-          <button className="ArticleList">
-            <Link to={`/board/${article?.board.board_id}`}>목록</Link>
-          </button>
-        </div>
-      </ArticleTopButtons>
-      <ArticleBox>
-        <ArticleHeader>
-          <div className="board">
-            <Link to={"/"}>{article?.board.board_name}</Link>
+  if (article) {
+    return (
+      <Wrapper>
+        <ArticleTopButtons ref={TopButtonsRef}>
+          <div className="left">
+            <button className="edit auth">
+              <Link to={"/write"}>수정</Link>
+            </button>
+            <button className="delete auth">
+              <Link to={"/"}>삭제</Link>
+            </button>
           </div>
-          <h3 className="title">{article?.title}</h3>
-          <div className="info">
-            <div className="left">
-              <div className="thumbArea">
-                <Link to={"/"}>
-                  <img
-                    src="https://ssl.pstatic.net/static/cafe/cafe_pc/default/cafe_profile_77.png?type=c77_77"
-                    alt="작성자 프로필 사진"
-                  />
-                  {/* 프로필 사진에 대해 서버에서 이미지를 가져오는 것인가? */}
-                </Link>
-              </div>
-              <div className="authorArea">
-                <div className="authorName">
-                  <Link to={"/"}>{article?.user.username}</Link>
+          <div className="right">
+            <button className="prevArticle">
+              {" "}
+              <Link to={"/"}>이전글</Link>
+            </button>
+            <button className="nextArticle">
+              <Link to={"/"}>다음글</Link>
+            </button>
+            <button className="ArticleList">
+              <Link to={`/board/${article?.article.board.id}`}>목록</Link>
+            </button>
+          </div>
+        </ArticleTopButtons>
+        <ArticleBox>
+          <ArticleHeader>
+            <div className="board">
+              <Link to={`/board/${article?.article.board.id}`}>
+                {article?.article.board.name}
+              </Link>
+            </div>
+            <h3 className="title">{article?.article.title}</h3>
+            <div className="info">
+              <div className="left">
+                <div className="thumbArea">
+                  <Link to={"/"}>
+                    <img
+                      src="https://ssl.pstatic.net/static/cafe/cafe_pc/default/cafe_profile_77.png?type=c77_77"
+                      alt="작성자 프로필 사진"
+                    />
+                    {/* 프로필 사진에 대해 서버에서 이미지를 가져오는 것인가? */}
+                  </Link>
                 </div>
-                <div className="articleInfo">
-                  <span className="createdAt">
-                    {article?.created_at
-                      .replace(/-/g, ".")
-                      .replace(/T\d\d:/, ". ")}
+                <div className="authorArea">
+                  <div className="authorName">
+                    <Link to={`/users/${article?.article.author.id}`}>
+                      {article?.article.author.nickname}
+                    </Link>
+                  </div>
+                  <div className="articleInfo">
+                    <span className="createdAt">
+                      {article?.article.createdAt
+                        .replace(/-/g, ".")
+                        .replace(/T\d\d:/, ". ")}
+                    </span>
+                    <span className="viewCount">
+                      조회 {article?.article.viewCount}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div className="right">
+                <button className="comments" onClick={() => scrollToComments()}>
+                  <img src={commentIcon} alt="댓글 아이콘" />
+                  <span>
+                    댓글 <strong>{commentCount}</strong>
                   </span>
-                  <span className="viewCount">조회 {article?.view_cnt}</span>
-                </div>
+                </button>
+                <button
+                  className="copyURL"
+                  onClick={() => handleCopyPathToClipBoard(location.pathname)}
+                >
+                  URL 복사
+                </button>
+                {/* <button className="menu" /> */}
+                {/* 메뉴 버튼도 있지만, 구현 기능이 포함되어 있지 않기 때문에 (지금 상황에선) 뺐습니다. */}
               </div>
             </div>
-            <div className="right">
-              <button className="comments" onClick={() => scrollToComments()}>
-                <img src={commentIcon} alt="댓글 아이콘" />
-                <span>
-                  댓글 <strong>{commentCount}</strong>
-                </span>
-              </button>
-              <button
-                className="copyURL"
-                onClick={() => handleCopyPathToClipBoard(location.pathname)}
-              >
-                URL 복사
-              </button>
-              {/* <button className="menu" /> */}
-              {/* 메뉴 버튼도 있지만, 구현 기능이 포함되어 있지 않기 때문에 (지금 상황에선) 뺐습니다. */}
-            </div>
-          </div>
-        </ArticleHeader>
-        <ArticleBody>{article?.content}</ArticleBody>
-        <ArticleFooter>
-          <div className="aboutAuthor">
-            <Link to={"/"}>
-              <img
-                src="https://ssl.pstatic.net/static/cafe/cafe_pc/default/cafe_profile_77.png?type=c77_77"
-                alt="작성자 프로필 사진"
-              />
-              {/* 프로필 사진에 대해 서버에서 이미지를 가져오는 것인가? */}
-              <span>
-                <strong>{article?.user.username}</strong>
-                님의 게시글 더보기
-              </span>
-            </Link>
-          </div>
-          <div className="articleInfo">
-            <div className="left">
-              <button className="likes" onClick={() => handleLikes()}>
+          </ArticleHeader>
+          <ArticleBody>{article?.article.content}</ArticleBody>
+          <ArticleFooter>
+            <div className="aboutAuthor">
+              <Link to={"/"}>
                 <img
-                  src={
-                    isArticleLiked
-                      ? "https://ca-fe.pstatic.net/web-section/static/img/ico-post-like-on-f-53535.svg?7eb6be9a4989d32af686acf09a07747d="
-                      : "https://ca-fe.pstatic.net/web-section/static/img/ico-post-like-f-53535.svg?a37a11006a542ce9949c0dd6779345b8="
-                  }
-                  alt="좋아요 아이콘"
+                  src="https://ssl.pstatic.net/static/cafe/cafe_pc/default/cafe_profile_77.png?type=c77_77"
+                  alt="작성자 프로필 사진"
                 />
+                {/* 프로필 사진에 대해 서버에서 이미지를 가져오는 것인가? */}
                 <span>
-                  좋아요 <strong>{article?.like_cnt}</strong>
+                  <strong>{article?.article.author.nickname}</strong>
+                  님의 게시글 더보기
                 </span>
-              </button>
-              <button className="comments">
-                <img src={commentIcon} alt="댓글 아이콘" />
-                <span>
-                  댓글 <strong>{commentCount}</strong>
-                </span>
-              </button>
+              </Link>
             </div>
-            <div className="right">
-              <button
-                className="share"
-                onClick={() => setIsShareModalOpen(!isShareModalOpen)}
-              >
-                <img src={shareIcon} alt="공유 아이콘" />
-                <span>공유</span>
-              </button>
-              {isShareModalOpen ? (
-                <ShareModal
-                  setIsShareModalOpen={setIsShareModalOpen}
-                  handleCopyPathToClipBoard={handleCopyPathToClipBoard}
-                />
-              ) : null}
+            <div className="articleInfo">
+              <div className="left">
+                <button className="likes" onClick={() => handleLikes()}>
+                  <img
+                    src={
+                      isArticleLiked
+                        ? "https://ca-fe.pstatic.net/web-section/static/img/ico-post-like-on-f-53535.svg?7eb6be9a4989d32af686acf09a07747d="
+                        : "https://ca-fe.pstatic.net/web-section/static/img/ico-post-like-f-53535.svg?a37a11006a542ce9949c0dd6779345b8="
+                    }
+                    alt="좋아요 아이콘"
+                  />
+                  <span>
+                    좋아요 <strong>{article?.article.likeCount}</strong>
+                  </span>
+                </button>
+                <button className="comments">
+                  <img src={commentIcon} alt="댓글 아이콘" />
+                  <span>
+                    댓글 <strong>{commentCount}</strong>
+                  </span>
+                </button>
+              </div>
+              <div className="right">
+                <button
+                  className="share"
+                  onClick={() => setIsShareModalOpen(!isShareModalOpen)}
+                >
+                  <img src={shareIcon} alt="공유 아이콘" />
+                  <span>공유</span>
+                </button>
+                {isShareModalOpen ? (
+                  <ShareModal
+                    setIsShareModalOpen={setIsShareModalOpen}
+                    handleCopyPathToClipBoard={handleCopyPathToClipBoard}
+                  />
+                ) : null}
+              </div>
             </div>
+          </ArticleFooter>
+          <div className="comments" ref={CommentsRef}>
+            <CommentBox articleId={articleId} />
           </div>
-        </ArticleFooter>
-        <div className="comments" ref={CommentsRef}>
-          <CommentBox articleId={articleId} />
-        </div>
-      </ArticleBox>
-      <ArticleBottomButtons>
-        <div className="left">
-          <button className="writeArticle">
-            <img src={writeArticleIcon} alt="글쓰기 아이콘" />
-            <span>글쓰기</span>
-          </button>
-          {/* <button className="reArticle">답글</button> */}
-          {/* 답글 기능은 없는 거 같아 일단 제외하겠습니다. */}
-          <button className="edit auth">수정</button>
-          <button
-            className="delete auth"
-            onClick={() => {
-              deleteArticle(Number(articleId));
-              navigate("/");
-            }}
-          >
-            삭제
-          </button>
-        </div>
-        <div className="right">
-          <button className="articleList">목록</button>
-          <button className="scrollTop" onClick={() => scrollToTop()}>
-            <img src={upTriangle} alt="위로 가기" />
-            <span>TOP</span>
-          </button>
-        </div>
-      </ArticleBottomButtons>
-      <AdvertArea />
-      <RelatedArticles
-        articleId={articleId}
-        boardId={article?.board.board_id}
-      />
-    </Wrapper>
-  );
+        </ArticleBox>
+        <ArticleBottomButtons>
+          <div className="left">
+            <button className="writeArticle">
+              <img src={writeArticleIcon} alt="글쓰기 아이콘" />
+              <span>글쓰기</span>
+            </button>
+            {/* <button className="reArticle">답글</button> */}
+            {/* 답글 기능은 없는 거 같아 일단 제외하겠습니다. */}
+            <button className="edit auth">수정</button>
+            <button
+              className="delete auth"
+              onClick={() => {
+                deleteArticle(Number(articleId));
+                navigate("/");
+              }}
+            >
+              삭제
+            </button>
+          </div>
+          <div className="right">
+            <button className="articleList">목록</button>
+            <button className="scrollTop" onClick={() => scrollToTop()}>
+              <img src={upTriangle} alt="위로 가기" />
+              <span>TOP</span>
+            </button>
+          </div>
+        </ArticleBottomButtons>
+        <AdvertArea />
+        <RelatedArticles
+          articleId={articleId}
+          boardId={article?.article.board.id}
+        />
+      </Wrapper>
+    );
+  }
 };
 export default Article;

--- a/naverCafe/src/components/body/contents/article/RelatedArticles.tsx
+++ b/naverCafe/src/components/body/contents/article/RelatedArticles.tsx
@@ -353,7 +353,7 @@ interface PropsRelatedArticles {
 }
 const RelatedArticles = ({ articleId, boardId }: PropsRelatedArticles) => {
   const { articleList } = useArticleList({ boardId: boardId });
-
+  console.log(articleList);
   const [onActiveButtonNumber, setOnActiveButtonNumber] = useState<
     number | null
   >(1);
@@ -375,7 +375,7 @@ const RelatedArticles = ({ articleId, boardId }: PropsRelatedArticles) => {
   };
 
   const relatedArticleList = useMemo(() => {
-    return articleList?.articles.map((article) => (
+    return articleList?.articleBrief.map((article) => (
       <Article
         $isArticleFocused={Number(articleId) === article.id ? true : false}
         key={article.id}
@@ -392,10 +392,10 @@ const RelatedArticles = ({ articleId, boardId }: PropsRelatedArticles) => {
             </span>
             <span
               className={
-                isNewArticle(article.created_at) ? "newArticle" : "oldArticle"
+                isNewArticle(article.createdAt) ? "newArticle" : "oldArticle"
               }
             >
-              {isNewArticle(article.created_at) ? (
+              {isNewArticle(article.createdAt) ? (
                 <img src={newArticleIcon} alt="새로운 게시물" />
               ) : (
                 ""
@@ -404,9 +404,9 @@ const RelatedArticles = ({ articleId, boardId }: PropsRelatedArticles) => {
           </div>
         </Link>
         <div className="right">
-          <div className="authorNickname">{article.user.nickname}</div>
+          <div className="authorNickname">{article.author.nickname}</div>
           <div className="createdAt">
-            {article.created_at
+            {article.createdAt
               .replace(/-/g, ". ")
               .replace(/T\d\d:\d\d:\d\d/, ".")}
           </div>
@@ -510,13 +510,13 @@ const RelatedArticles = ({ articleId, boardId }: PropsRelatedArticles) => {
     };
     if (articleId) {
       // 현재 보고 있는 article이 전체 article list에서 몇번째 index에 있는지 조사합니다.
-      const articleIndex = articleList?.articles.findIndex(
+      const articleIndex = articleList?.articleBrief.findIndex(
         (article) => article.id === Number(articleId)
       );
       if (articleIndex) {
-        if (articleList?.articles[articleIndex + 2] !== undefined) {
+        if (articleList?.articleBrief[articleIndex + 2] !== undefined) {
           return newRelatedArticles(articleIndex + 2);
-        } else if (articleList?.articles[articleIndex + 1] !== undefined) {
+        } else if (articleList?.articleBrief[articleIndex + 1] !== undefined) {
           return newRelatedArticles(articleIndex + 1);
         } else {
           return newRelatedArticles(articleIndex);

--- a/naverCafe/src/components/body/contents/article/comment/Comment.tsx
+++ b/naverCafe/src/components/body/contents/article/comment/Comment.tsx
@@ -126,7 +126,7 @@ const Comment = ({ comment, articleId, refetchComments }: PropsComment) => {
               <div className="content">{comment.content}</div>
               <div className="commentInfo">
                 <span>
-                  {comment.last_modified.replace(/-/g, ".").replace(/T/, ". ")}
+                  {comment.lastModified.replace(/-/g, ".").replace(/T/, ". ")}
                 </span>
                 <span>
                   <button

--- a/naverCafe/src/components/body/contents/article/comment/CommentWriter.tsx
+++ b/naverCafe/src/components/body/contents/article/comment/CommentWriter.tsx
@@ -7,7 +7,7 @@ import {
   postComment,
   postReComment,
 } from "../../../../../API/CommentAPI";
-import { useUserContext } from "../../../../../contexts/UserContext";
+import { useAuthContext } from "../../../../../contexts/AuthContext";
 
 const Wrapper = styled.div<{
   $commentLength: number;
@@ -130,7 +130,7 @@ const CommentWriter = ({
 }: PropsCommentWriter) => {
   const [commentInput, setCommentInput] = useState<string>("");
   const commentTextarea = useRef<HTMLTextAreaElement | null>(null);
-  const myInfo = useUserContext();
+  const { myUsername } = useAuthContext();
 
   const handleCommentTextareaHeight = () => {
     if (commentTextarea.current !== null) {
@@ -195,7 +195,7 @@ const CommentWriter = ({
   return (
     <Wrapper $commentLength={commentInput.length} $type={info.type}>
       <div className="CommentWriter">
-        <div className="writerName">{myInfo.userNickname}</div>
+        <div className="writerName">{myUsername}</div>
         <textarea
           ref={commentTextarea}
           placeholder="댓글을 남겨보세요"

--- a/naverCafe/src/components/body/contents/article/comment/ReComment.tsx
+++ b/naverCafe/src/components/body/contents/article/comment/ReComment.tsx
@@ -79,7 +79,7 @@ interface PropsReComment {
   reComment: {
     id: number;
     content: string;
-    last_modified: string;
+    lastModified: string;
     nickname: string;
   };
   articleId: string | undefined;
@@ -133,9 +133,7 @@ const ReComment = ({
               <div className="content">{reComment.content}</div>
               <div className="commentInfo">
                 <span>
-                  {reComment.last_modified
-                    .replace(/-/g, ".")
-                    .replace(/T/, ". ")}
+                  {reComment.lastModified.replace(/-/g, ".").replace(/T/, ". ")}
                 </span>
                 <span>
                   <button

--- a/naverCafe/src/contexts/AuthContext.tsx
+++ b/naverCafe/src/contexts/AuthContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export const AuthContext = createContext<{
+  myUsername: string;
+  accessToken: string;
+} | null>(null);
+export function useAuthContext() {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error("can't find AuthContext");
+  return context;
+}

--- a/naverCafe/src/contexts/LoginContext.tsx
+++ b/naverCafe/src/contexts/LoginContext.tsx
@@ -1,20 +1,20 @@
-import { createContext, useContext} from "react";
-import { type UserLoginInput } from "../Types";
-import { error } from "console";
+// import { createContext, useContext} from "react";
+// import { type UserLoginInput } from "../Types";
+// import { error } from "console";
 
-export const AuthContext = createContext<{
-  login: (username: string, password: string) => void;
-  auth: { token: string, logout: () => void; userInfo: UserLoginInput } | null;
-}>({
-  login: (username: string, password: string): void => {
-    throw new Error("Not implemented");
-  },
-  auth: null,
-});
+// export const AuthContext = createContext<{
+//   login: (username: string, password: string) => void;
+//   auth: { token: string, logout: () => void; userInfo: UserLoginInput } | null;
+// }>({
+//   login: (username: string, password: string): void => {
+//     throw new Error("Not implemented");
+//   },
+//   auth: null,
+// });
 
-// eslint-disable-next-line react-refresh/only-export-components
-export function useAuth() {
-  const auth = useContext(AuthContext).auth;
-  if (!auth) throw error("Cannot find AuthContext");
-  return auth;
-}
+// // eslint-disable-next-line react-refresh/only-export-components
+// export function useAuth() {
+//   const auth = useContext(AuthContext).auth;
+//   if (!auth) throw error("Cannot find AuthContext");
+//   return auth;
+// }

--- a/naverCafe/src/pages/Login.tsx
+++ b/naverCafe/src/pages/Login.tsx
@@ -1,9 +1,8 @@
 import styled, { css } from "styled-components";
 import { Link } from "react-router-dom";
 import { useState } from "react";
-import axios from "axios";
 import { useNavigate } from "react-router-dom";
-import { baseURL } from "../Constants";
+import { login } from "../API/UserAPI";
 
 const Wrapper = styled.div`
   width: 458px;
@@ -151,8 +150,8 @@ const Inner = styled.div`
   } */
 `;
 const IDLogin = styled.div<{
-  $userNameLength: number;
-  $userPasswordLength: number;
+  $inputUsernameLength: number;
+  $inputPasswordLength: number;
   $isLoginMaintained: boolean;
 }>`
   & > .id,
@@ -199,7 +198,7 @@ const IDLogin = styled.div<{
     }
     & > .deleteLogo {
       display: ${(props) =>
-        props.$userNameLength !== 0 ? "inline-block" : "none"};
+        props.$inputUsernameLength !== 0 ? "inline-block" : "none"};
     }
   }
   & > .password {
@@ -216,7 +215,7 @@ const IDLogin = styled.div<{
     }
     & > .deleteLogo {
       display: ${(props) =>
-        props.$userPasswordLength !== 0 ? "inline-block" : "none"};
+        props.$inputPasswordLength !== 0 ? "inline-block" : "none"};
     }
   }
   .deleteLogo {
@@ -328,10 +327,13 @@ const Find = styled.div`
     }
   }
 `;
-
-const Login = () => {
-  const [userName, setUserName] = useState<string>("");
-  const [userPassword, setUserPassword] = useState<string>("");
+interface PropsLogin {
+  setMyUsername: (value: string) => void;
+  setAccessToken: (value: string) => void;
+}
+const Login = ({ setMyUsername, setAccessToken }: PropsLogin) => {
+  const [inputUsername, setInputUsername] = useState<string>("");
+  const [inputPassword, setInputPassword] = useState<string>("");
   const [isIDLoginSelected, setIsIDLoginSelected] = useState<boolean>(true);
   const [isLoginMaintained, setIsLoginMaintained] = useState<boolean>(false);
 
@@ -341,43 +343,34 @@ const Login = () => {
 
   const navigate = useNavigate();
 
-  const handleLogin = () => {
+  const handleLogin = async () => {
     setIsErrorOnBoth(false);
-    if (userName.length == 0) {
+    if (inputUsername.length == 0) {
       setIsErrorOnId(true);
       return;
     } else {
       setIsErrorOnId(false);
     }
-    if (userPassword.length === 0) {
+    if (inputPassword.length === 0) {
       setIsErrorOnPassword(true);
       return;
     } else {
       setIsErrorOnPassword(false);
     }
-    login();
-    return;
-  };
-
-  const login = () => {
-    console.log({
-      username: userName,
-      password: userPassword,
-    });
-    return axios
-      .post(baseURL + "/api/v1/login", {
-        username: userName,
-        password: userPassword,
-      })
+    await login({ username: inputUsername, password: inputPassword })
       .then((res) => {
         console.log(res);
+        setMyUsername(inputUsername);
+        setAccessToken(res.data.accessToken);
+        // 테스트를 위해 안정화될때까진 localStorage 이용하겠습니다.
+        window.localStorage.setItem("accessToken", res.data.accessToken);
         navigate("/");
-        return res;
       })
       .catch((err) => {
         console.log(err);
         setIsErrorOnBoth(true);
       });
+    return;
   };
 
   return (
@@ -400,8 +393,8 @@ const Login = () => {
         <Inner>
           {isIDLoginSelected ? (
             <IDLogin
-              $userNameLength={userName.length}
-              $userPasswordLength={userPassword.length}
+              $inputUsernameLength={inputUsername.length}
+              $inputPasswordLength={inputPassword.length}
               $isLoginMaintained={isLoginMaintained}
             >
               <div className="id">
@@ -409,22 +402,25 @@ const Login = () => {
                 <input
                   type="text"
                   placeholder="아이디"
-                  value={userName}
-                  onChange={(e) => setUserName(e.target.value)}
+                  value={inputUsername}
+                  onChange={(e) => setInputUsername(e.target.value)}
                 />
-                <span className="deleteLogo" onClick={() => setUserName("")} />
+                <span
+                  className="deleteLogo"
+                  onClick={() => setInputUsername("")}
+                />
               </div>
               <div className="password">
                 <span className="passwordLogo" />
                 <input
                   type="password"
                   placeholder="비밀번호"
-                  value={userPassword}
-                  onChange={(e) => setUserPassword(e.target.value)}
+                  value={inputPassword}
+                  onChange={(e) => setInputPassword(e.target.value)}
                 />
                 <span
                   className="deleteLogo"
-                  onClick={() => setUserPassword("")}
+                  onClick={() => setInputPassword("")}
                 />
               </div>
               <div className="loginSetting">


### PR DESCRIPTION
안녕하세요, 일단 대강 틀은 잡아두었습니다. 바뀐 내용 중에 중요한 내용은 다음과 같습니다.

1. access token 관리 및 자신의 정보 context
 - 로그인할 때 access token을 저장하는 방식으로 2가지 방안이 있을 것 같습니다. 첫째, App.tsx의 state로 관리하기. 둘째, localStorage에 저장하기. 첫째 방법으로 한다면 새로고침했을 때 access token이 날아가버려서 다시 로그인을 해야한다는 번거로움이 존재하고, 두번째 방법으로 한다면 저번 회의에서 논의했던 것처럼 해킹 공격에 취약해집니다. 이를 해결할 수 있는 방법은 세미나 때 했던 refresh token을 사용하는 수밖에 없는데, 슬랙에 이 기능 요청을 드렸으나, 구현이 어렵고 시간이 오래걸린다면 그냥 localStorage에 저장할 셈입니다. 일단 back과 연결은 되어야 하니까 당분간 localStorage에 저장하여 사용하는 것으로 하겠습니다.
  또, 현재는 myUsername이라는 state를 App.tsx에서 관리하고 authContext로서 사용합니다. 현재는 로그인이 성공했을 때 입력했던 username을 저장하는 구조인데, 이 역시 새로고침하면 날아가므로, 자신의 정보를 불러올 수 있는 새로운 api 기능을 백엔드분들께 요청드린 상황입니다. 이 api를 사용한다면 access token만 있으면 자신의 정보를 불러올 수 있으므로 새로고침에도 다시 api 요청을 하면 됩니다. 그렇게 된다면, 자신의 id, username, name, nickname 4가지 요소가 담긴 객체를 context로서 사용할 생각입니다. 이렇게 된다면, 로그인되어있는지 여부는 위 객체가 잘 정의되었는지 여부로서 확인 가능합니다.

3. Type 중 ArticleType 변경
- 백엔드 api 보니까 article에서 특정 게시물 요청에서 받을 수 있는 response의 타입이 조금씩 다른 것 같습니다.(어떤 건 isLiked 프로퍼티가 있고 article 프로퍼티 안에 저희가 원하는 article 정보가 들어있는 경우도 있고, articleBrief 프로퍼티 안에 저희가 원하는 article 정보가 들어있는 경우도 있습니다.) 따라서 ArticleType은 저희가 원하는, 다음과 같은 타입으로 정하고, 받아오는 response의 타입은 그것을 다루는 각 함수에서 따로 정의해두면 좋을 것 같습니다. 예를 들어, board api의  useArticleList() 함수 내부의 articleList의 type을 `{articleBrief: ArticleType[]} | null` 로 정하는 것 처럼이요.
```export type ArticleType = {
  id: number;
  title: string;
  content: string;
  createdAt: string;
  viewCount: number;
  likeCount: number;
  commentCount: number;
  author: {
    id: number;
    nickname: string;
    registerDate: string;
    email: string;
    rank: string;
    visitCount: number;
    articlesCount: number;
    commentsCount: number;
    accessToken: string;
  };
  board: {
    id: number;
    name: string;
  };
  allowComments: boolean;
  isNotification: boolean;
};
```
3. 백 api가 자주 바뀌는듯합니다.
- 백 api가 자주 바뀌는 거 같아서 바뀌는 것에 맞춰 계속 수정해야할 것 같습니다...!

남은 기간동안 파이팅입니다!! 