### PR TITLE
소셜 로그인 이슈 해결

### DIFF
--- a/naverCafe/src/components/Header.tsx
+++ b/naverCafe/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { waffleCafe } from "../Constants";
 
 const Wrapper = styled.div`
   display: inline-block;
@@ -179,8 +180,8 @@ const Header = () => {
         <a href="/">
           <div>
             <span>
-              <h1>카페 이름</h1>
-              <p>카페 주소</p>
+              <h1>{waffleCafe.name}</h1>
+              <p>{waffleCafe.url}</p>
             </span>
           </div>
         </a>

--- a/naverCafe/src/pages/Login.tsx
+++ b/naverCafe/src/pages/Login.tsx
@@ -355,8 +355,11 @@ const Login = () => {
       const code = new URL(window.location.href).searchParams.get("code");
       console.log(code);
       if (code) {
-        // If code exists in the URL, send a request to exchange it for an access token
-        exchangeCodeForToken(code);
+        if (localStorage.getItem("accessToken")) {
+          navigate("/");
+        } else {
+          exchangeCodeForToken(code);
+        }
       }
     };
 
@@ -366,13 +369,9 @@ const Login = () => {
           baseURL + `/api/v1/auth/socialSignin/naver?code=${code}`
         );
         const tokenData = await tokenResponse.data;
-        // Save the access token to localStorage
         console.log(tokenData);
         localStorage.setItem("accessToken", tokenData.accessToken);
-        // Clear the URL query string to remove the code parameter
-        // window.history.replaceState({}, document.title, "/");
-        // navigate("/");
-        window.location.reload();
+        navigate("/");
       } catch (error) {
         console.error("Error exchanging code for token:", error);
       }


### PR DESCRIPTION
소셜로그인 이슈 해결했습니다.

실제 네이버 창에서 소셜로그인 성공 후 다시 돌아올 때의 주소를 `redirect_uri=http://ec2-15-165-161-107.ap-northeast-2.compute.amazonaws.com:5173/login`와 같은 식으로 login 페이지를 향하게 수정하였습니다.

access token을 받고 메인 창으로 이동하는 이벤트도 잘 작동하는 것 확인했습니다!