### PR TITLE
웹폰트 및 다크모드 방지

### DIFF
--- a/naverCafe/src/contexts/BoardStyle/ArticleBoardContext/NoticeRow.tsx
+++ b/naverCafe/src/contexts/BoardStyle/ArticleBoardContext/NoticeRow.tsx
@@ -189,7 +189,7 @@ export const NoticeTr = ({
           <button>
             <span
               className="nickname"
-              onClick={() => navigate(`/users/${notice.author.id}`)}
+              onClick={() => navigate(`/users/${notice.author.nickname}`)}
             >
               {notice.author.nickname}
             </span>

--- a/naverCafe/src/contexts/BoardStyle/ArticleBoardContext/Table.tsx
+++ b/naverCafe/src/contexts/BoardStyle/ArticleBoardContext/Table.tsx
@@ -545,7 +545,9 @@ const CardViewUl = ({
                 <div className="user_info">
                   <div
                     className="pers_nick_area"
-                    onClick={() => navigate(`/users/${article.author.id}`)}
+                    onClick={() =>
+                      navigate(`/users/${article.author.nickname}`)
+                    }
                   >
                     {article.author.nickname}
                   </div>
@@ -738,7 +740,7 @@ export const ArticleTable = ({
                         className="nickname"
                         onClick={() => {
                           if (myProfile) {
-                            navigate(`/users/${article.author.id}`);
+                            navigate(`/users/${article.author.nickname}`);
                           } else {
                             navigate(`/login`);
                           }

--- a/naverCafe/src/contexts/StyleContext.tsx
+++ b/naverCafe/src/contexts/StyleContext.tsx
@@ -4,7 +4,7 @@ export const GlobalStyle = createGlobalStyle`
   // naverCafe 전체적으로 적용되는 css입니다.
   :root {
     /* font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif; */
-    font-family: '맑은 고딕', Malgun Gothic, Helvetica,sans-serif;
+    font-family: 'Apple SD Gothic Neo', '애플 SD 산돌고딕 Neo', 나눔 고딕, 'NanumGothic', Helvetica,sans-serif;
     line-height: 1.5;
     font-weight: 400;
 
@@ -43,6 +43,14 @@ export const GlobalStyle = createGlobalStyle`
       background-color: #ffffff;
     }
   }
+  @media (prefers-color-scheme: dark) {
+  body {
+    background-color: white;
+    color: #213547;
+    /* 기타 다크 모드에서 변경할 스타일 */
+  }
+}
+
 `;
 export const Logo = css`
   display: block;


### PR DESCRIPTION
- 다크 모드를 완전히 못 하게 막을 수 없어, color-scheme: dark일 때 background를 white으로 하는 것으로 수정했습니다.
- 웹폰트를 맑은 고딕 대신 애플 산돌 고딕 neo 및 나눔고딕으로 대신했는데, 브라우저마다 웹폰트를 다운받기도 하고 안 그러는 것 같기도 해서... 한번 글씨체가 바뀌었는지 확인해주시면 감사하겠습니다!!
- 6번 에러 (글 클릭 했을 때 undefined) 해결하였습니다.